### PR TITLE
Make guzzle requirement less restrictive for 3.x releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
 	],
 	"require": {
 		"php": ">=5.3.0",
-		"guzzle/guzzle": "~3.8.0"
+		"guzzle/guzzle": "^3.8.0"
 	},
 	"autoload": {
 		"psr-0": {


### PR DESCRIPTION
The `composer.json` file currently restricts the Guzzle requirement to the minor version `3.8.x`.  This PR aims to allow all minor versions in the `3.x` release, with `3.8.x` as a minimum requirement.