### PR TITLE
Fix issue with GET request parameters

### DIFF
--- a/src/AfterShip/Core/Request.php
+++ b/src/AfterShip/Core/Request.php
@@ -25,7 +25,7 @@ class Request
 
 		switch (strtoupper($request_type)) {
 			case "GET":
-				$request = $this->callGET($this->_api_url . '/' . $this->_api_version . '/' . $url, $headers, array('query' => $data));
+				$request = $this->callGET($this->_api_url . '/' . $this->_api_version . '/' . $url, $headers, $data);
 				break;
 			case "POST":
 				$request = $this->callPOST($this->_api_url . '/' . $this->_api_version . '/' . $url, $headers, json_encode($data));


### PR DESCRIPTION
Parameters to GET requests were not correctly passed to the API, as the provided array was double-wrapped, producing $parameters['query']['query']['parameter'], in place of $parameters['query']['parameter'].