### PR TITLE
Fix blank exception message when server returns no json

### DIFF
--- a/src/AfterShip/Core/Request.php
+++ b/src/AfterShip/Core/Request.php
@@ -80,6 +80,11 @@ class Request
 		$code = $info['http_code'];
 		if ($code < 200 || $code >= 300) {
 			$parsed = json_decode($response);
+			
+			if($parsed === NULL) {
+				throw new AftershipException("Error processing request - received HTTP error code $code");
+			}
+			
 			$err_code = '';
 			$err_message = '';
 			$err_type = '';


### PR DESCRIPTION
If the server returns an HTTP error, and doesn't include a JSON response, an exception is raised containing the HTTP error code, rather than a blank message