### PR TITLE
Populate aftership error code when throwing an exception from Request…

### DIFF
--- a/src/AfterShip/Core/Request.php
+++ b/src/AfterShip/Core/Request.php
@@ -97,7 +97,7 @@ class Request
 			if (isset($parsed->meta->type)) {
 				$err_type = $parsed->meta->type;
 			}
-			throw new AftershipException("$err_type: $err_code - $err_message");
+			throw new AftershipException("$err_type: $err_code - $err_message", $err_code);
 		}
 		curl_close($curl);
 		return json_decode($response, true);


### PR DESCRIPTION
… to being able to get error code in catch block

Currently it is not possible to use something like this

if ($exception->getCode() === 4003) {
